### PR TITLE
Fix for Internal error while editing hooks

### DIFF
--- a/app/helpers/hooks_helper.rb
+++ b/app/helpers/hooks_helper.rb
@@ -14,7 +14,7 @@ module HooksHelper
 
     tag_options = { id: field_id, class: "#{custom_field.field_format}_cf" }
 
-    field_format = Redmine::CustomFieldFormat.find_by_name(custom_field.field_format)
+    field_format = custom_field.field_format
     case field_format.try(:edit_as)
       when 'date'
         text_field_tag(field_name, custom_value.value, tag_options.merge(size: 10)) +


### PR DESCRIPTION
Any attempt to add hook (global or per project) resulted in internal server error  when custom fields where present (ActionView::Template::Error (uninitialized constant Redmine::CustomFieldFormat)). Original code used class Redmine::CustomFieldFormat, which has been removed from Redmine long time ago.